### PR TITLE
Fix TinyMCE editor reuse

### DIFF
--- a/Web/css/librebooking.css
+++ b/Web/css/librebooking.css
@@ -599,15 +599,9 @@ input.mid-number {
     display: none !important;
 }
 
-.trumbowyg-editor p,
 .notesValue p,
 .descriptionValue p {
     margin: 0;
-}
-
-.trumbowyg-modal-submit {
-    background-color: var(--primary) !important;
-    color: var(--text-color-btn) !important;
 }
 
 .descriptionValue a,
@@ -616,8 +610,7 @@ input.mid-number {
 .noteContent a,
 .announcement a,
 .announcementText a,
-.announcementContent a,
-.trumbowyg-editor a {
+.announcementContent a {
     color: var(--primary);
 }
 

--- a/Web/scripts/admin/announcement.js
+++ b/Web/scripts/admin/announcement.js
@@ -67,13 +67,13 @@ function AnnouncementManagement(opts) {
 
 		ConfigureAsyncForm(elements.addForm, getSubmitCallback(options.actions.add));
 		ConfigureAsyncForm(elements.deleteForm, getSubmitCallback(options.actions.deleteAnnouncement));
-		ConfigureAsyncForm(elements.form, function () {
-			// Sanitize the content of the Trumbowyg before sending it
-			const rawContent = $('#editText').trumbowyg('html');
-			const sanitizedHtml = DOMPurify.sanitize(rawContent);
+                ConfigureAsyncForm(elements.form, function () {
+                        // Sanitize the content of TinyMCE before sending it
+                        const rawContent = tinymce.get('editText').getContent();
+                        const sanitizedHtml = DOMPurify.sanitize(rawContent);
 
-			// Update the textarea with clean content before submitting
-			$('#editText').val(sanitizedHtml);
+                        // Update the editor with clean content before submitting
+                        tinymce.get('editText').setContent(sanitizedHtml);
 
 			return options.submitUrl + "?aid=" + getActiveId() + "&action=" + options.actions.edit;
 		});

--- a/tpl/Admin/Resources/manage_resources.tpl
+++ b/tpl/Admin/Resources/manage_resources.tpl
@@ -1,4 +1,4 @@
-{include file='globalheader.tpl' InlineEdit=true DataTable=true Trumbowyg=true}
+{include file='globalheader.tpl' InlineEdit=true DataTable=true TinyMCE=true}
 
 <div id="page-manage-resources" class="admin-page">
 	<div class="clearfix border-bottom mb-3">
@@ -419,7 +419,7 @@
 																	{assign var=description value=''}
 																{/if}
 																{strip}
-																	<div class="descriptionValue" data-type="trumbowyg"
+                                                                              <div class="descriptionValue" data-type="tinymce"
 																		data-pk="{$id}" data-value="{$description}"
 																		data-name="{FormKeys::RESOURCE_DESCRIPTION}">
 																		{if $resource->HasDescription()}
@@ -445,7 +445,7 @@
 																	{assign var=notes value=''}
 																{/if}
 																{strip}
-																	<div class="notesValue" data-type="trumbowyg"
+                                                                              <div class="notesValue" data-type="tinymce"
 																		data-pk="{$id}" data-value="{$notes}"
 																		data-name="{FormKeys::RESOURCE_NOTES}">
 																		{if $resource->HasNotes()}
@@ -2057,7 +2057,7 @@
 
 {csrf_token}
 
-{include file="javascript-includes.tpl" InlineEdit=true Clear=true DataTable=true Trumbowyg=true }
+{include file="javascript-includes.tpl" InlineEdit=true Clear=true DataTable=true TinyMCE=true }
 {datatable tableId=$tableId}
 {jsfile src="ajax-helpers.js"}
 {jsfile src="autocomplete.js"}
@@ -2067,60 +2067,77 @@
 {jsfile src="search-clear.js"}
 
 <script type="text/javascript">
-	function addTrumbowygType() {
-		var Trumbowyg = function(options) {
-			this.init('trumbowyg', options, Trumbowyg.defaults);
-		};
-		$.fn.editableutils.inherit(Trumbowyg, $.fn.editabletypes.abstractinput);
-		$.extend(Trumbowyg.prototype, {
-			render: function() {
-				// Set any provided classes or attributes
-				this.setClass();
-				this.setAttr('placeholder');
+        function addTinyMceType() {
+                var TinyMce = function(options) {
+                        this.init('tinymce', options, TinyMce.defaults);
+                };
+                $.fn.editableutils.inherit(TinyMce, $.fn.editabletypes.abstractinput);
+                $.extend(TinyMce.prototype, {
+                        render: function() {
+                                this.setClass();
+                                this.setAttr('placeholder');
 
-				this.$input.trumbowyg({
-					tagsToRemove: ['script', 'link'],
-					removeformatPasted: true,
-					urlProtocol: true,
-					btns: [
-						['bold', 'italic', 'underline'],
-						['link'],
-						['unorderedList', 'orderedList']
-					]
-				});
-			},
+                                const id = 'tinymce_' + (new Date()).getTime();
+                                this.$input.attr('id', id);
 
-			value2html: function(value, element) {
-				const sanitizedHtml = DOMPurify.sanitize(value || '');
-				$(element).html(sanitizedHtml);
-			},
+                                tinymce.init({
+                                        target: this.$input[0],
+                                        menubar: false,
+                                        plugins: 'link lists',
+                                        toolbar: 'bold italic underline | bullist numlist | link',
+                                        setup: function(editor) {
+                                                editor.on('blur', function() {
+                                                        editor.save();
+                                                });
+                                        }
+                                });
+                        },
 
-			html2value: function(html) {
-				return html || '';
-			},
+                        value2html: function(value, element) {
+                                const sanitizedHtml = DOMPurify.sanitize(value || '');
+                                $(element).html(sanitizedHtml);
+                        },
 
-			activate: function() {
-				if (this.$input.data('trumbowyg')) {
-					this.$input.trumbowyg('open');
-				}
-			},
-			value2input: function(value) {
-				this.$input.trumbowyg('html', value);
-			},
-			input2value: function() {
-				const sanitizedHtml = DOMPurify.sanitize(this.$input.trumbowyg('html'));
-				return sanitizedHtml;
-			}
-		});
+                        html2value: function(html) {
+                                return html || '';
+                        },
 
-		Trumbowyg.defaults = $.extend({}, $.fn.editabletypes.abstractinput.defaults, {
-			tpl: '<textarea></textarea>',
-			inputclass: 'input-large',
-			placeholder: null,
-			rows: 7
-		});
-		$.fn.editabletypes.trumbowyg = Trumbowyg;
-	}
+                        activate: function() {
+                                const editor = tinymce.get(this.$input.attr('id'));
+                                if (editor) {
+                                        editor.focus();
+                                }
+                        },
+                        value2input: function(value) {
+                                const editor = tinymce.get(this.$input.attr('id'));
+                                if (editor) {
+                                        editor.setContent(value || '');
+                                }
+                        },
+                        input2value: function() {
+                                const editor = tinymce.get(this.$input.attr('id'));
+                                if (editor) {
+                                        return DOMPurify.sanitize(editor.getContent());
+                                }
+                                return this.$input.val();
+                        },
+
+                        destroy: function() {
+                                const editor = tinymce.get(this.$input.attr('id'));
+                                if (editor) {
+                                        editor.remove();
+                                }
+                        }
+                });
+
+                TinyMce.defaults = $.extend({}, $.fn.editabletypes.abstractinput.defaults, {
+                        tpl: '<textarea></textarea>',
+                        inputclass: 'input-large',
+                        placeholder: null,
+                        rows: 7
+                });
+                $.fn.editabletypes.tinymce = TinyMce;
+        }
 
 	function setUpPopovers() {
 		$('[rel="popover"]').popover({
@@ -2254,7 +2271,7 @@
 	}
 
 	$(document).ready(function() {
-		addTrumbowygType();
+                addTinyMceType();
 		setUpPopovers();
 		setUpEditables();
 		setupCustomAttributesIcon();

--- a/tpl/Admin/manage_announcements.tpl
+++ b/tpl/Admin/manage_announcements.tpl
@@ -1,4 +1,4 @@
-{include file='globalheader.tpl' Select2=true DataTable=true Trumbowyg=true}
+{include file='globalheader.tpl' Select2=true DataTable=true TinyMCE=true}
 
 <div id="page-manage-announcements" class="admin-page">
 	<h1 class="border-bottom mb-3">{translate key=ManageAnnouncements}</h1>
@@ -262,7 +262,7 @@
 		</div>
 	</div>
 
-	{include file="javascript-includes.tpl" Select2=true DataTable=true Trumbowyg=true Resizimg=true}
+        {include file="javascript-includes.tpl" Select2=true DataTable=true TinyMCE=true Resizimg=true}
 	{datatable tableId={$tableId}}
 	{control type="DatePickerSetupControl" ControlId="BeginDate" AltId="formattedBeginDate"}
 	{control type="DatePickerSetupControl" ControlId="EndDate" AltId="formattedEndDate"}
@@ -277,39 +277,31 @@
 
 	<script type="text/javascript">
 		$(document).ready(function() {
-			const defaultTrumbowygOptions = {
-				btns: [
-					['viewHTML'],
-					['undo', 'redo'],
-					['formatting'],
-					['strong', 'em', 'del'],
-					['link'],
-					['insertImage'],
-					['justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull'],
-					['unorderedList', 'orderedList']
-				],
-				tagsToRemove: ['script', 'link'],
-				removeformatPasted: true,
-				urlProtocol: true
-			};
+                        const defaultTinyMceOptions = {
+                                menubar: false,
+                                plugins: 'link lists',
+                                toolbar: 'undo redo | bold italic underline | alignleft aligncenter alignright alignjustify | bullist numlist | link'
+                        };
 
-			$('#addAnnouncement').trumbowyg(defaultTrumbowygOptions);
+                        {literal}tinymce.init(Object.assign({}, defaultTinyMceOptions, {selector: '#addAnnouncement'}));{/literal}
 
-			$(document).on('shown.bs.modal', '#editDialog', function() {
-				// Obtaining and sanitizing content
-				const rawContent = $('#editText').val();
-				const sanitizedHtml = DOMPurify.sanitize(rawContent);
+                        $(document).on('shown.bs.modal', '#editDialog', function() {
+                                const rawContent = $('#editText').val();
+                                const sanitizedHtml = DOMPurify.sanitize(rawContent);
 
-				// Initialize editor
-				$('#editText').trumbowyg(defaultTrumbowygOptions)
-					.trumbowyg('html', sanitizedHtml);
-			});
+                                const existing = tinymce.get('editText');
+                                if (existing) {
+                                        existing.setContent(sanitizedHtml);
+                                } else {
+                                        {literal}tinymce.init(Object.assign({}, defaultTinyMceOptions, {selector: '#editText'})).then(function(editors) { editors[0].setContent(sanitizedHtml); });{/literal}
+                                }
+                        });
 
-			$(document).on('hidden.bs.modal', '#editDialog', function() {
-				if ($('#editText').data('trumbowyg')) {
-					$('#editText').trumbowyg('destroy');
-				}
-			});
+                        $(document).on('hidden.bs.modal', '#editDialog', function() {
+                                if (tinymce.get('editText')) {
+                                        tinymce.get('editText').remove();
+                                }
+                        });
 
 			var actions = {
 				add: '{ManageAnnouncementsActions::Add}',

--- a/tpl/globalheader.tpl
+++ b/tpl/globalheader.tpl
@@ -42,8 +42,8 @@
         {if isset($Validator) && $Validator}
             {cssfile src="css/bootstrapValidator.min.css" rel="stylesheet"}
         {/if}
-        {if isset($Trumbowyg) && $Trumbowyg}
-            {cssfile src="css/trumbowyg.min.css" rel="stylesheet"}
+        {if isset($TinyMCE) && $TinyMCE}
+            {* TinyMCE does not require additional CSS *}
         {/if}
     {else}
         <link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/smoothness/jquery-ui.css" type="text/css" />
@@ -57,10 +57,8 @@
                 href="https://cdnjs.cloudflare.com/ajax/libs/jquery.bootstrapvalidator/0.5.3/css/bootstrapValidator.min.css"
                 type="text/css" />
         {/if}
-        {if isset($Trumbowyg) && $Trumbowyg}
-            <link rel="stylesheet"
-            href="https://cdnjs.cloudflare.com/ajax/libs/Trumbowyg/2.27.3/ui/trumbowyg.min.css"
-            type="text/css" />
+        {if isset($TinyMCE) && $TinyMCE}
+            {* TinyMCE does not require additional CSS *}
         {/if}
 
     {/if}

--- a/tpl/javascript-includes.tpl
+++ b/tpl/javascript-includes.tpl
@@ -8,9 +8,9 @@
     {if isset($Validator) && $Validator}
         {jsfile src="js/bootstrapvalidator/bootstrapValidator.min.js"}
     {/if}
-    {if isset($Trumbowyg) && $Trumbowyg}
+    {if isset($TinyMCE) && $TinyMCE}
         {jsfile src="js/purify.min.js"}
-        {jsfile src="js/trumbowyg.min.js"}
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/tinymce/6.7.0/tinymce.min.js" referrerpolicy="origin"></script>
     {/if}
 {else}
     <script type="text/javascript" src="https://cdn.jsdelivr.net/lodash/4.16.3/lodash.min.js"></script>
@@ -24,11 +24,9 @@
         <script type="text/javascript"
             src="https://cdnjs.cloudflare.com/ajax/libs/jquery.bootstrapvalidator/0.5.3/js/bootstrapValidator.min.js"></script>
     {/if}
-    {if isset($Trumbowyg) && $Trumbowyg}
-        <script src="//rawcdn.githack.com/RickStrahl/jquery-resizable/0.35/dist/jquery-resizable.min.js"></script>
+    {if isset($TinyMCE) && $TinyMCE}
         <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.4.0/purify.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/Trumbowyg/2.27.3/trumbowyg.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/Trumbowyg/2.27.3/plugins/resizimg/trumbowyg.resizimg.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/tinymce/6.7.0/tinymce.min.js" referrerpolicy="origin"></script>
     {/if}
 {/if}
 {if isset($InlineEdit) && $InlineEdit}


### PR DESCRIPTION
## Summary
- fix TinyMCE lifecycle on resources page
- reinitialize TinyMCE when editing announcements
- escape TinyMCE init lines with Smarty {literal} blocks

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432bde57388322b8ba83cc6b03683a